### PR TITLE
backups: Add a backup mechanism for our firefly-iii

### DIFF
--- a/.backup.env
+++ b/.backup.env
@@ -1,0 +1,25 @@
+# Configuration file for offen/docker-volume-backup
+# batesste-firefly-iii
+# January 2025
+#
+# See [1] for a full description of all the backup configurations
+# available.
+#
+# [1]: https://offen.github.io/docker-volume-backup/reference/
+
+# Run every day at 2300
+BACKUP_CRON_EXPRESSION="0 0 23 * * ?"
+
+# Gzip compress backups using all available cpu threads
+BACKUP_COMPRESSION="gz"
+GZIP_PARALLELISM=0
+
+# The backup name
+BACKUP_FILENAME="batesste-firefly-iii-backup-%Y-%m-%dT%H-%M-%S.{{ .Extension }}"
+
+# AWS S3 Configuration
+AWS_S3_BUCKET_NAME="batesste-firefly-iii-backups"
+
+# Pruning of old backups
+BACKUP_RETENTION_DAYS="90"
+BACKUP_PRUNING_PREFIX="batesste-firefly-iii-backup-"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,8 +9,8 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Create .aws.creds.env file
         run: |
-          echo "AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" > .aws.creds.env
-          echo "AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> .aws.creds.env
+          echo "AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"" > .aws.creds.env
+          echo "AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"" >> .aws.creds.env
       - name: Docker Compose based smoke-test
         uses: hoverkraft-tech/compose-action@v2.0.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *~
+.aws.creds.env

--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ is handy.
 # Credentials
 
 The first time I set this up I created an account. I do not see any
-easy way to automate this. Also two docker volumes were created. In
-time I will perhaps use [this container][ref-backup] to back these up
-on a regular basis.
+easy way to automate this. Also two docker volumes were created.
+
+# Backups
+
+I use [this container][ref-backup] to back these up the volumes
+associated with this service on a regular daily basis to a bucket on
+my [AWS S3][ref-aws-s3] account. See the [configuration
+file](./.backup.env) file for configuration.
 
 # Importing
 
@@ -33,3 +38,4 @@ an easy way to directly access those accounts.
 [ref-firefly]: https://docs.firefly-iii.org/
 [ref-importer]: https://docs.firefly-iii.org/how-to/data-importer/installation/docker/
 [ref-backup]: https://github.com/offen/docker-volume-backup
+[ref-aws-s3]: https://aws.amazon.com/s3/

--- a/batesste-firefly-iii.dc.yml
+++ b/batesste-firefly-iii.dc.yml
@@ -61,6 +61,17 @@ services:
     networks:
       - firefly_iii
 
+  backup:
+    image: offen/docker-volume-backup:latest
+    container_name: firefly_iii_backup
+    restart: always
+    env_file:
+      - .backup.env
+      - .aws.creds.env
+    volumes:
+      - firefly_iii_upload:/backup/upload-backup:ro
+      - firefly_iii_db:/backup/db-backup:ro
+
 volumes:
    firefly_iii_upload:
    firefly_iii_db:


### PR DESCRIPTION
Our docker-based deployment of firefly-iii uses two docker volumes to store our important data. We use this cool container [1] to backup these volumes to AWS S3 daily.

[1]: https://github.com/offen/docker-volume-backup