### PR TITLE
volumes: Move to exact naming of docker volumes

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,5 +1,8 @@
 name: batesste-firefly-iii
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
 
 jobs:
   smoke-test:
@@ -11,6 +14,10 @@ jobs:
         run: |
           echo "AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"" > .aws.creds.env
           echo "AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"" >> .aws.creds.env
+      - name: Create the external docker volumes
+        run: |
+          docker volume create batesste-firefly-iii-upload
+          docker volume create batesste-firefly-iii-db
       - name: Docker Compose based smoke-test
         uses: hoverkraft-tech/compose-action@v2.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ We use the Docker method to install and we include the [firefly-ii
 data importer][ref-importer]. We also include import configs in JSON
 format in the [import configs folder](./import-configs). We can use
 these for the relevant bank account imports.
+
+Note that before you run the ```docker compose``` command for the
+first time you need to create two docker volumes.
+```bash
+docker volume create batesste-firefly-iii-upload
+docker volume create batesste-firefly-iii-db
+```
+Then
 ```
 docker compose \
   -f batesste-firefly-iii.dc.yml \

--- a/batesste-firefly-iii.dc.yml
+++ b/batesste-firefly-iii.dc.yml
@@ -11,13 +11,13 @@ services:
 
   app:
     image: fireflyiii/core:latest
-    hostname: app
-    container_name: firefly_iii_core
+    hostname: firefly-iii-app
+    container_name: batesste-firefly-iii-core
     networks:
-      - firefly_iii
+      - batesste-firefly-iii
     restart: always
     volumes:
-      - firefly_iii_upload:/var/www/html/storage/upload
+      - batesste-firefly-iii-upload:/var/www/html/storage/upload
     env_file: .env
     ports:
       - '1080:8080'
@@ -26,22 +26,22 @@ services:
 
   db:
     image: mariadb:lts
-    hostname: db
-    container_name: firefly_iii_db
+    hostname: firefly-iii-db
+    container_name: batesste-firefly-iii-db
     networks:
-      - firefly_iii
+      - batesste-firefly-iii
     restart: always
     env_file: .db.env
     volumes:
-      - firefly_iii_db:/var/lib/mysql
+      - batesste-firefly-iii-db:/var/lib/mysql
 
   importer:
     image: fireflyiii/data-importer:latest
-    hostname: importer
+    hostname: firefly-iii-importer
+    container_name: batesste-firefly-iii-importer
     restart: always
-    container_name: firefly_iii_importer
     networks:
-      - firefly_iii
+      - batesste-firefly-iii
     ports:
       - '1081:8080'
     depends_on:
@@ -55,32 +55,36 @@ services:
     # STATIC_CRON_TOKEN must be *exactly* 32 characters long
     #
     image: alpine:latest
-    container_name: firefly_iii_cron
+    container_name: batesste-firefly-iii-cron
     restart: always
-    command: sh -c "echo \"0 3 * * * wget -qO- http://app:8080/api/v1/cron/REPLACEME\" | crontab - && crond -f -L /dev/stdout"
+    command: sh -c "echo \"0 3 * * * wget -qO- http://firefly-iii-app:8080/api/v1/cron/REPLACEME\" | crontab - && crond -f -L /dev/stdout"
     networks:
-      - firefly_iii
+      - batesste-firefly-iii
 
   backup:
     image: offen/docker-volume-backup:latest
-    hostname: backup
-    container_name: firefly_iii_backup
+    hostname: firefly-iii-backup
+    container_name: batesste-firefly-iii-backup
     restart: always
     env_file:
       - .backup.env
       - .aws.creds.env
     volumes:
-      - firefly_iii_upload:/backup/upload-backup:ro
-      - firefly_iii_db:/backup/db-backup:ro
+      - batesste-firefly-iii-upload:/backup/upload-backup:ro
+      - batesste-firefly-iii-db:/backup/db-backup:ro
     depends_on:
       - app
     networks:
-      - firefly_iii
+      - batesste-firefly-iii
 
 volumes:
-   firefly_iii_upload:
-   firefly_iii_db:
+  batesste-firefly-iii-upload:
+    external: true
+    name: batesste-firefly-iii-upload
+  batesste-firefly-iii-db:
+    external: true
+    name: batesste-firefly-iii-db
 
 networks:
-  firefly_iii:
+  batesste-firefly-iii:
     driver: bridge


### PR DESCRIPTION
To make it easier to track the docker volumes make them exernal and give then a canonical name. Update the CI to this new way of doing things too.