### PR TITLE
time-zone: Set the timezone in the backup container.

### DIFF
--- a/batesste-firefly-iii.dc.yml
+++ b/batesste-firefly-iii.dc.yml
@@ -72,6 +72,8 @@ services:
     volumes:
       - batesste-firefly-iii-upload:/backup/upload-backup:ro
       - batesste-firefly-iii-db:/backup/db-backup:ro
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
     depends_on:
       - app
     networks:


### PR DESCRIPTION
The backup container does not have timezone detection so we have to pass it in from the host [1].

[1]: https://offen.github.io/docker-volume-backup/how-tos/set-container-timezone.html